### PR TITLE
Fixed bug with clearing search bar without clear button not reenabling control buttons

### DIFF
--- a/options/groupeditor.js
+++ b/options/groupeditor.js
@@ -263,7 +263,6 @@ var groupEditor = (() => {
     onSearchInput(event) {
       let api = urlsGridOptions.api;
       let searchBarElem = document.getElementById('urlsSearchBar');
-      console.log('test1');
       api.setQuickFilter(searchBarElem.value);
       //Reenable control buttons if search bar is cleared
       searchBarElem.value == '' ? editor.enableUrlsButtons() : editor.disableUrlsButtons();

--- a/options/groupeditor.js
+++ b/options/groupeditor.js
@@ -262,8 +262,11 @@ var groupEditor = (() => {
     },
     onSearchInput(event) {
       let api = urlsGridOptions.api;
-      api.setQuickFilter(document.getElementById('urlsSearchBar').value);
-      editor.disableUrlsButtons();
+      let searchBarElem = document.getElementById('urlsSearchBar');
+      console.log('test1');
+      api.setQuickFilter(searchBarElem.value);
+      //Reenable control buttons if search bar is cleared
+      searchBarElem.value == '' ? editor.enableUrlsButtons() : editor.disableUrlsButtons();
     },
     onClickClearSearch(event) {
       document.getElementById('urlsSearchBar').value = '';
@@ -365,8 +368,10 @@ var groupEditor = (() => {
     },
     onSearchInput(event) {
       let api = substitutionsGridOptions.api;
-      api.setQuickFilter(document.getElementById('substitutionsSearchBar').value);
-      editor.disableSubstitutionsButtons();
+      let searchBarElem = document.getElementById('substitutionsSearchBar')
+      api.setQuickFilter(searchBarElem.value);
+      //Reenable control buttons if search bar is cleared
+      searchBarElem.value == '' ? editor.enableSubstitutionsButtons() : editor.disableSubstitutionsButtons();
     },
     onClickClearSearch(event) {
       document.getElementById('substitutionsSearchBar').value = '';


### PR DESCRIPTION
I noticed a small bug with the code I had pushed last time with disabling the control buttons if the user was searching. It did not reenable them if the user cleared the search bar without using the button. I fixed that here.